### PR TITLE
Fix: badDescription hide method updated

### DIFF
--- a/Old Fashion Description/scripts.js
+++ b/Old Fashion Description/scripts.js
@@ -41,6 +41,8 @@ function SetVars() {
     //Check if there actually is the new description to prevent error
     if (badDescription != null) {
       badDescription.remove();
+      //patch for removing the new description on newer versions of the website
+      badDescription.style.visibility = "ENGAGEMENT_PANEL_VISIBILITY_HIDDEN";
     }
   });
 


### PR DESCRIPTION
Small change to fix the bad description not disappearing on current versions of Youtube.